### PR TITLE
Make '--debug' a flag instead of a boolean option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make `--debug` a flag instead of a boolean option
 
 ## [1.0.1] - 2020-01-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Command-line flag         | Environment variable      | Description
 `--target`         | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests. Default: `function`
 `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http` or `event`
 `--source`         | `FUNCTION_SOURCE`         | The path to the file containing your function. Default: `main.py` (in the current working directory)
-`--debug`          | `DEBUG`                   | A boolean flag that allows to run functions-framework to run in debug mode, including live reloading. Default: `False`
+`--debug`          | `DEBUG`                   | A flag that allows to run functions-framework to run in debug mode, including live reloading. Default: `False`
 
 # Enable CloudEvents
 

--- a/src/functions_framework/cli.py
+++ b/src/functions_framework/cli.py
@@ -29,7 +29,7 @@ from functions_framework import create_app
     default="http",
 )
 @click.option("--port", envvar="PORT", type=click.INT, default=8080)
-@click.option("--debug", envvar="DEBUG", type=click.BOOL, default=False)
+@click.option("--debug", envvar="DEBUG", is_flag=True)
 def cli(target, source, signature_type, port, debug):
     host = "0.0.0.0"
     app = create_app(target, source, signature_type)


### PR DESCRIPTION
I.e. instead of `--debug TRUE` or `--debug=True`, users can just specify `--debug`.