### PR TITLE
Improve documentation around Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After you've written your function, you can simply deploy it from your local mac
 
 ## Cloud Run/Cloud Run on GKE
 
-Once you've written your function and added the Functions Framework to your `requirements.txt` file, all that's left is to create a container image. [Check out the Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy) for Python to create a container image and deploy it to Cloud Run. You'll write a `Dockerfile` when you build your container. This `Dockerfile` allows you to specify exactly what goes into your container (including custom binaries, a specific operating system, and more). [Here is an example `Dockerfile` that calls Functions Framework.](./examples/cloud_run_http/Dockerfile)
+Once you've written your function and added the Functions Framework to your `requirements.txt` file, all that's left is to create a container image. [Check out the Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy) for Python to create a container image and deploy it to Cloud Run. You'll write a `Dockerfile` when you build your container. This `Dockerfile` allows you to specify exactly what goes into your container (including custom binaries, a specific operating system, and more). [Here is an example `Dockerfile` that calls Functions Framework.](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/master/examples/cloud_run_http)
 
 If you want even more control over the environment, you can [deploy your container image to Cloud Run on GKE](https://cloud.google.com/run/docs/quickstarts/prebuilt-deploy-gke). With Cloud Run on GKE, you can run your function on a GKE cluster, which gives you additional control over the environment (including use of GPU-based instances, longer timeouts and more).
 
@@ -149,7 +149,7 @@ For more details on this signature type, check out the Google Cloud Functions do
 
 # Advanced Examples
 
-More advanced guides can be found in the [`examples/`](./examples/) directory.
+More advanced guides can be found in the [`examples/`](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/master/examples/) directory.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After you've written your function, you can simply deploy it from your local mac
 
 ## Cloud Run/Cloud Run on GKE
 
-Once you've written your function and added the Functions Framework to your `requirements.txt` file, all that's left is to create a container image. [Check out the Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy) for Python to create a container image and deploy it to Cloud Run. You'll write a `Dockerfile` when you build your container. This `Dockerfile` allows you to specify exactly what goes into your container (including custom binaries, a specific operating system, and more).
+Once you've written your function and added the Functions Framework to your `requirements.txt` file, all that's left is to create a container image. [Check out the Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy) for Python to create a container image and deploy it to Cloud Run. You'll write a `Dockerfile` when you build your container. This `Dockerfile` allows you to specify exactly what goes into your container (including custom binaries, a specific operating system, and more). [Here is an example `Dockerfile` that calls Functions Framework.](./examples/cloud_run_http/Dockerfile)
 
 If you want even more control over the environment, you can [deploy your container image to Cloud Run on GKE](https://cloud.google.com/run/docs/quickstarts/prebuilt-deploy-gke). With Cloud Run on GKE, you can run your function on a GKE cluster, which gives you additional control over the environment (including use of GPU-based instances, longer timeouts and more).
 

--- a/examples/cloud_run_http/Dockerfile
+++ b/examples/cloud_run_http/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $APP_HOME
 COPY . .
 
 # Install production dependencies.
-RUN pip install gunicorn functions-framework
+RUN pip install functions-framework
 RUN pip install -r requirements.txt
 
 # Run the web service on container startup.

--- a/examples/cloud_run_http/README.md
+++ b/examples/cloud_run_http/README.md
@@ -29,11 +29,8 @@ COPY . .
 RUN pip install gunicorn functions-framework
 RUN pip install -r requirements.txt
 
-# Run the web service on container startup. Here we use the gunicorn
-# webserver, with one worker process and 8 threads.
-# For environments with multiple CPU cores, increase the number of workers
-# to be equal to the cores available.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 -e FUNCTION_TARGET=hello functions_framework:app
+# Run the web service on container startup.
+CMD exec functions-framework --target=hello
 ```
 
 Start the container locally by running `docker build` and `docker run`:

--- a/examples/cloud_run_http/README.md
+++ b/examples/cloud_run_http/README.md
@@ -26,7 +26,7 @@ WORKDIR $APP_HOME
 COPY . .
 
 # Install production dependencies.
-RUN pip install gunicorn functions-framework
+RUN pip install functions-framework
 RUN pip install -r requirements.txt
 
 # Run the web service on container startup.


### PR DESCRIPTION
* Fix the inline example in the `cloud-run-http`
* Add a link to this sample Dockerfile in the main README
