### PR TITLE
Fix how Missingtargetexception raise

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -247,14 +247,13 @@ def create_app(target=None, source=None, signature_type=None):
         app.make_response = handle_none
 
     # Extract the target function from the source file
-    try:
-        function = getattr(source_module, target)
-    except AttributeError:
+    if not hasattr(source_module, target):
         raise MissingTargetException(
             "File {source} is expected to contain a function named {target}".format(
                 source=source, target=target
             )
         )
+    function = getattr(source_module, target)
 
     # Check that it is a function
     if not isinstance(function, types.FunctionType):


### PR DESCRIPTION
As-is, this raises an `AttributeError` followed by a "while handling this exception, another exception occurred", followed by the `MissingTargetException`.

It's confusing to include the `AttributeError` in this traceback, so instead we can just test for the attribute and raise the exception if it's missing.

**Before:**
```
$ functions-framework --target test
Traceback (most recent call last):
  File "~/googlecloudplatform/functions-framework-python/src/functions_framework/__init__.py", line 251, in create_app
    function = getattr(source_module, target)
AttributeError: module 'main' has no attribute 'test'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "~/.pyenv/versions/3.8.2/bin/ff", line 33, in <module>
    sys.exit(load_entry_point('functions-framework', 'console_scripts', 'ff')())
  File "~/pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "~/git/googlecloudplatform/functions-framework-python/src/functions_framework/_cli.py", line 37, in _cli
    app = create_app(target, source, signature_type)
  File "~/git/googlecloudplatform/functions-framework-python/src/functions_framework/__init__.py", line 253, in create_app
    raise MissingTargetException(
functions_framework.exceptions.MissingTargetException: File ~/git/googlecloudplatform/functions-framework-python/tests/test_functions/http_trigger/main.py is expected to contain a function named test
```

**After:**
```
$ functions-framework --target test
Traceback (most recent call last):
  File "~/.pyenv/versions/3.8.2/bin/ff", line 33, in <module>
    sys.exit(load_entry_point('functions-framework', 'console_scripts', 'ff')())
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "~/.pyenv/versions/3.8.2/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "~/git/googlecloudplatform/functions-framework-python/src/functions_framework/_cli.py", line 37, in _cli
    app = create_app(target, source, signature_type)
  File "~/git/googlecloudplatform/functions-framework-python/src/functions_framework/__init__.py", line 251, in create_app
    raise MissingTargetException(
functions_framework.exceptions.MissingTargetException: File ~/git/googlecloudplatform/functions-framework-python/tests/test_functions/http_trigger/main.py is expected to contain a function named test
```