### PR TITLE
ci: don't run when pushing to non-master branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Python Lint CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,5 +1,9 @@
 name: Python Unit CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 jobs:
   test:
     strategy:


### PR DESCRIPTION
This CI PR slightly changes the config to not run on every push.

- Run CI whenever:
  - Pushing to master
  - Pull requests

(Sorry for the extra PR)