### PR TITLE
docs: format and add buildpack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ curl http://my-url
 
 All without needing to worry about writing an HTTP server or complicated request handling logic.
 
-# Features
+## Features
 
 *   Spin up a local development server for quick testing
 *   Invoke a function in response to a request
 *   Automatically unmarshal events conforming to the [CloudEvents](https://cloudevents.io/) spec
 *   Portable between serverless platforms
 
-# Installation
+## Installation
 
 Install the Functions Framework via `pip`:
 
@@ -48,7 +48,9 @@ Or, for deployment, add the Functions Framework to your `requirements.txt` file:
 functions-framework==2.0.0
 ```
 
-# Quickstart: Hello, World on your local machine
+## Quickstarts
+
+### Quickstart: Hello, World on your local machine
 
 Create an `main.py` file with the following contents:
 
@@ -66,7 +68,7 @@ functions-framework --target=hello
 Open http://localhost:8080/ in your browser and see *Hello world!*.
 
 
-# Quickstart: Set up a new project
+### Quickstart: Set up a new project
 
 Create a `main.py` file with the following contents:
 
@@ -100,9 +102,34 @@ curl localhost:8080
 # Output: Hello world!
 ```
 
-# Run your function on serverless platforms
+### Quickstart: Build a Deployable Container
 
-## Google Cloud Functions
+1. Install [Docker](https://store.docker.com/search?type=edition&offering=community) and the [`pack` tool](https://buildpacks.io/docs/install-pack/).
+
+1. Build a container from your function using the Functions [buildpacks](https://github.com/GoogleCloudPlatform/buildpacks):
+	```sh
+	pack build \
+		--builder gcr.io/buildpacks/builder:v1 \
+		--env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
+		--env GOOGLE_FUNCTION_TARGET=hello \
+		my-first-function
+	```
+
+1. Start the built container:
+	```sh
+	docker run --rm -p 8080:8080 my-first-function
+	# Output: Serving function...
+	```
+
+1. Send requests to this function using `curl` from another terminal window:
+	```sh
+	curl localhost:8080
+	# Output: Hello World!
+	```
+
+## Run your function on serverless platforms
+
+### Google Cloud Functions
 
 This Functions Framework is based on the [Python Runtime on Google Cloud Functions](https://cloud.google.com/functions/docs/concepts/python-runtime).
 
@@ -110,17 +137,17 @@ On Cloud Functions, using the Functions Framework is not necessary: you don't ne
 
 After you've written your function, you can simply deploy it from your local machine using the `gcloud` command-line tool. [Check out the Cloud Functions quickstart](https://cloud.google.com/functions/docs/quickstart).
 
-## Cloud Run/Cloud Run on GKE
+### Cloud Run/Cloud Run on GKE
 
 Once you've written your function and added the Functions Framework to your `requirements.txt` file, all that's left is to create a container image. [Check out the Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/build-and-deploy) for Python to create a container image and deploy it to Cloud Run. You'll write a `Dockerfile` when you build your container. This `Dockerfile` allows you to specify exactly what goes into your container (including custom binaries, a specific operating system, and more). [Here is an example `Dockerfile` that calls Functions Framework.](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/master/examples/cloud_run_http)
 
 If you want even more control over the environment, you can [deploy your container image to Cloud Run on GKE](https://cloud.google.com/run/docs/quickstarts/prebuilt-deploy-gke). With Cloud Run on GKE, you can run your function on a GKE cluster, which gives you additional control over the environment (including use of GPU-based instances, longer timeouts and more).
 
-## Container environments based on Knative
+### Container environments based on Knative
 
 Cloud Run and Cloud Run on GKE both implement the [Knative Serving API](https://www.knative.dev/docs/). The Functions Framework is designed to be compatible with Knative environments. Just build and deploy your container to a Knative environment.
 
-# Configure the Functions Framework
+## Configure the Functions Framework
 
 You can configure the Functions Framework using command-line flags or environment variables. If you specify both, the environment variable will be ignored.
 
@@ -134,7 +161,7 @@ You can configure the Functions Framework using command-line flags or environmen
 | `--debug`          | `DEBUG`                   | A flag that allows to run functions-framework to run in debug mode, including live reloading. Default: `False`                                                                                   |
 
 
-# Enable Google Cloud Functions Events
+## Enable Google Cloud Functions Events
 
 The Functions Framework can unmarshall incoming
 Google Cloud Functions [event](https://cloud.google.com/functions/docs/concepts/events-triggers#events) payloads to `data` and `context` objects.
@@ -158,7 +185,7 @@ documentation on
 
 See the [running example](examples/cloud_run_event).
 
-# Enable CloudEvents
+## Enable CloudEvents
 
 The Functions Framework can unmarshall incoming
 [CloudEvent](http://cloudevents.io) payloads to a `cloudevent` object.
@@ -176,11 +203,11 @@ To enable automatic unmarshalling, set the function signature type to `cloudeven
 
 See the [running example](examples/cloud_run_cloudevents).
 
-# Advanced Examples
+## Advanced Examples
 
 More advanced guides can be found in the [`examples/`](https://github.com/GoogleCloudPlatform/functions-framework-python/blob/master/examples/) directory.
 You can also find examples on using the CloudEvent Python SDK [here](https://github.com/cloudevents/sdk-python).
 
-# Contributing
+## Contributing
 
 Contributions to this library are welcome and encouraged. See [CONTRIBUTING](CONTRIBUTING.md) for more information on how to get started.


### PR DESCRIPTION
- Adds GCP buildpack instructions. Fixes https://github.com/GoogleCloudPlatform/functions-framework-python/issues/90
- Formats doc so we don't have many H1 titles, rather H2s.