### PR TITLE
Add dry-run command-line flag to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ You can configure the Functions Framework using command-line flags or environmen
 | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http`, `event` or `cloudevent` |
 | `--source`         | `FUNCTION_SOURCE`         | The path to the file containing your function. Default: `main.py` (in the current working directory)                                                                                             |
 | `--debug`          | `DEBUG`                   | A flag that allows to run functions-framework to run in debug mode, including live reloading. Default: `False`                                                                                   |
+| `--dry-run`        | `DRY_RUN`                 | A flag that allows for testing the function build from the configuration without creating a server. Default: `False` |
 
 ## Enable Google Cloud Functions Events
 


### PR DESCRIPTION
I've been using this Functions Framework library, which has been great for developing and debugging, and noticed the --help text lists `--dry-run` as a command-line option though it is not documented in the README.

Support for the dry-run flag was added in version 1.1.1 (as noted in the changelog), and it may also be helpful to have it added alongside the other command-line options in the main documentation so that more users can be aware of this functionality!