### PR TITLE
Upgrade conformance test version to v0.3.9

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.15'
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:
         functionType: 'http'
         useBuildpacks: false
@@ -32,7 +32,7 @@ jobs:
         cmd: "'functions-framework --source tests/conformance/main.py --target write_http --signature-type http'"
 
     - name: Run event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:
         functionType: 'legacyevent'
         useBuildpacks: false
@@ -40,7 +40,7 @@ jobs:
         cmd: "'functions-framework --source tests/conformance/main.py --target write_legacy_event --signature-type event'"
 
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.7
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.9
       with:
         functionType: 'cloudevent'
         useBuildpacks: false


### PR DESCRIPTION
Also use Go 1.15. Go is only used to build the conformance test client.
