### PR TITLE
Update GCF Python 3.7 backwards-compatible logging

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -524,6 +524,22 @@ def test_legacy_function_log_severity(monkeypatch, capfd, mode, expected):
     assert expected in captured
 
 
+def test_legacy_function_log_exception(monkeypatch, capfd):
+    source = TEST_FUNCTIONS_DIR / "http_log_exception" / "main.py"
+    target = "function"
+    severity = '"severity": "ERROR"'
+    traceback = "Traceback (most recent call last)"
+
+    monkeypatch.setenv("ENTRY_POINT", target)
+
+    client = create_app(target, source).test_client()
+    resp = client.post("/")
+    captured = capfd.readouterr().err
+    assert resp.status_code == 200
+    assert severity in captured
+    assert traceback in captured
+
+
 def test_legacy_function_returns_none(monkeypatch):
     source = TEST_FUNCTIONS_DIR / "returns_none" / "main.py"
     target = "function"

--- a/tests/test_functions/http_log_exception/main.py
+++ b/tests/test_functions/http_log_exception/main.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Function used in Worker tests of legacy GCF Python 3.7 logging."""
+import logging
+
+X_GOOGLE_FUNCTION_NAME = "gcf-function"
+X_GOOGLE_ENTRY_POINT = "function"
+HOME = "/tmp"
+
+
+def function(request):
+    """Test function which logs exceptions.
+
+    Args:
+      request: The HTTP request which triggered this function.
+    """
+    try:
+        raise Exception
+    except:
+        logging.exception("log")
+    return None


### PR DESCRIPTION
Fixes issues in backwards compatibility for GCF Python 3.7.