### PR TITLE
fix: Add a DummyErrorHandler

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -348,3 +348,14 @@ class LazyWSGIApp:
 
 
 app = LazyWSGIApp()
+
+
+class DummyErrorHandler:
+    def __init__(self):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+
+errorhandler = DummyErrorHandler()

--- a/tests/test_cloudevent_functions.py
+++ b/tests/test_cloudevent_functions.py
@@ -16,9 +16,9 @@ import pathlib
 
 import pytest
 
-from cloudevents.http import CloudEvent, from_http, to_binary, to_structured
+from cloudevents.http import CloudEvent, to_binary, to_structured
 
-from functions_framework import LazyWSGIApp, create_app, exceptions
+from functions_framework import create_app
 
 TEST_FUNCTIONS_DIR = pathlib.Path(__file__).resolve().parent / "test_functions"
 TEST_DATA_DIR = pathlib.Path(__file__).resolve().parent / "test_data"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -25,7 +25,7 @@ import pytest
 
 import functions_framework
 
-from functions_framework import LazyWSGIApp, create_app, exceptions
+from functions_framework import LazyWSGIApp, create_app, errorhandler, exceptions
 
 TEST_FUNCTIONS_DIR = pathlib.Path.cwd() / "tests" / "test_functions"
 
@@ -452,6 +452,12 @@ def test_lazy_wsgi_app(monkeypatch, target, source, signature_type):
         pretend.call(*args, **kwargs),
         pretend.call(*args, **kwargs),
     ]
+
+
+def test_dummy_error_handler():
+    @errorhandler("foo", bar="baz")
+    def function():
+        pass
 
 
 def test_class_in_main_is_in_right_module():


### PR DESCRIPTION
Fixes #136. This allows the `functions_framework.errorhandler` to be called on import outside the context of app creation.