### PR TITLE
fix: cloudevent conversion conformance tests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: '1.15'
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.10
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'http'
         useBuildpacks: false
@@ -32,7 +32,7 @@ jobs:
         cmd: "'functions-framework --source tests/conformance/main.py --target write_http --signature-type http'"
 
     - name: Run event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.10
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'legacyevent'
         useBuildpacks: false
@@ -40,7 +40,7 @@ jobs:
         cmd: "'functions-framework --source tests/conformance/main.py --target write_legacy_event --signature-type event'"
 
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.10
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
       with:
         functionType: 'cloudevent'
         useBuildpacks: false

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build/
 dist/
 .coverage
 .vscode/
+function_output.json
+serverlog_stderr.txt
+serverlog_stdout.txt

--- a/tests/test_data/firebase-db-cloudevent-output.json
+++ b/tests/test_data/firebase-db-cloudevent-output.json
@@ -1,0 +1,15 @@
+{
+    "specversion": "1.0",
+    "type": "google.firebase.database.document.v1.written",
+    "source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
+    "subject": "refs/gcf-test/xyz",
+    "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "time": "2020-09-29T11:32:00.000Z",
+    "datacontenttype": "application/json",
+    "data": {
+      "data": null,
+      "delta": {
+        "grandchild": "other"
+      }
+    }
+  }

--- a/tests/test_data/firebase-db-legacy-input.json
+++ b/tests/test_data/firebase-db-legacy-input.json
@@ -1,0 +1,19 @@
+{
+    "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+    "params": {
+      "child": "xyz"
+    },
+    "auth": {
+      "admin": true
+    },
+    "domain": "firebaseio.com",
+    "data": {
+      "data": null,
+      "delta": {
+        "grandchild": "other"
+      }
+    },
+    "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+    "timestamp": "2020-09-29T11:32:00.000Z",
+    "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
+  }

--- a/tests/test_functions/cloudevents/converted_background_event.py
+++ b/tests/test_functions/cloudevents/converted_background_event.py
@@ -35,6 +35,8 @@ def function(cloudevent):
                 "attr1": "attr1-value",
             },
             "data": "dGVzdCBtZXNzYWdlIDM=",
+            "messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+            "publishTime": "2020-09-29T11:32:00.000Z",
         },
     }
 


### PR DESCRIPTION
This commit updates the legacy event to cloud event conversion logic to:

- include the `messageId` and `publishTime` fields in the data payload of Pub/Sub events
- include the location in the source field of firebasedatabase events

fixes #139 
