### PR TITLE
fix: Lazy-load functions post worker fork

### DIFF
--- a/src/functions_framework/_http/flask.py
+++ b/src/functions_framework/_http/flask.py
@@ -21,5 +21,8 @@ class FlaskApplication:
         self.debug = debug
         self.options = options
 
+        # Go ahead and load the user's function as soon as possible
+        self.app.load_function()
+
     def run(self):
         self.app.run(self.host, self.port, debug=self.debug, **self.options)

--- a/src/functions_framework/_http/gunicorn.py
+++ b/src/functions_framework/_http/gunicorn.py
@@ -23,10 +23,15 @@ class GunicornApplication(gunicorn.app.base.BaseApplication):
             "threads": 8,
             "timeout": 0,
             "loglevel": "error",
+            "post_fork": self.post_fork,
         }
         self.options.update(options)
         self.app = app
         super().__init__()
+
+    def post_fork(self, server, worker):
+        # Load the function only once the worker process has forked
+        self.app.load_function()
 
     def load_config(self):
         for key, value in self.options.items():


### PR DESCRIPTION
To ensure that all user code is loaded and executed within the same process, delay module execution until the application and server have been created, and after the worker has forked.