### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2021-10-08
+### Added
+- Support Python 3.10
+
 ## [2.2.1] - 2021-06-01
 ### Changed
 - Update GCF Python 3.7 backwards-compatible logging ([#131])

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     keywords="functions-framework",
     packages=find_packages(where="src"),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39}-{ubuntu-latest,macos-latest,windows-latest},lint
+envlist = py{35,36,37,38,39,310}-{ubuntu-latest,macos-latest,windows-latest},lint
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
- ✔️ Python Unit CI
- ✔️ Python Lint CI
- ❌ Conformance CI
  - It seems unrelated to the new changes
  - It randomly fails for 3.8, 3.9, or 3.10, then cancels the other builds
  - Error: `Validation failure: failed to get response from function for "firebase-db1": failed to send CloudEvent: 500:`
- Note: I had to change `python-version`: `[x.y]` into `['x.y']` or it would only pick up `3.1` instead of `3.10`