### PR TITLE
fix: update to newest conformance test Action

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,27 +21,30 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.0
       with:
+        version: 'v0.3.12'
         functionType: 'http'
         useBuildpacks: false
         validateMapping: false
         cmd: "'functions-framework --source tests/conformance/main.py --target write_http --signature-type http'"
 
     - name: Run event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.0
       with:
+        version: 'v0.3.12'
         functionType: 'legacyevent'
         useBuildpacks: false
         validateMapping: true
         cmd: "'functions-framework --source tests/conformance/main.py --target write_legacy_event --signature-type event'"
 
     - name: Run cloudevent conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.12
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.0
       with:
+        version: 'v0.3.12'
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: true


### PR DESCRIPTION
Use the newest conformance test Action release that allows pinning the version of the tests that get run correctly.

<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
