### PR TITLE
feat: Add ability to pass options to create_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ You can configure the Functions Framework using command-line flags or environmen
 | `--source`         | `FUNCTION_SOURCE`         | The path to the file containing your function. Default: `main.py` (in the current working directory)                                                                                             |
 | `--debug`          | `DEBUG`                   | A flag that allows to run functions-framework to run in debug mode, including live reloading. Default: `False`                                                                                   |
 | `--dry-run`        | `DRY_RUN`                 | A flag that allows for testing the function build from the configuration without creating a server. Default: `False` |
+| `--options`        | `OPTIONS`                 | Pass in options to be used to override defaults in the HTTP Server. Options should be in the format `"KEY:VALUE"`. For example `--options="workers:3" --options="thread:9"` will set the default workers to 3 and threads to 9. If using the Environment variable, then make sure multiple options are seprated by a whitespace. Default: `{}` |
 
 ## Enable Google Cloud Function Events
 

--- a/src/functions_framework/_cli.py
+++ b/src/functions_framework/_cli.py
@@ -33,7 +33,7 @@ from functions_framework._http import create_server
 @click.option("--port", envvar="PORT", type=click.INT, default=8080)
 @click.option("--debug", envvar="DEBUG", is_flag=True)
 @click.option("--dry-run", envvar="DRY_RUN", is_flag=True)
-@click.option("--options", "-o", envvar="OPTIONS", multiple=True)
+@click.option("--options", "-o", envvar="OPTIONS", multiple=True, default=[])
 def _cli(target, source, signature_type, host, port, debug, dry_run, options):
     app = create_app(target, source, signature_type)
     if dry_run:

--- a/src/functions_framework/_cli.py
+++ b/src/functions_framework/_cli.py
@@ -33,11 +33,15 @@ from functions_framework._http import create_server
 @click.option("--port", envvar="PORT", type=click.INT, default=8080)
 @click.option("--debug", envvar="DEBUG", is_flag=True)
 @click.option("--dry-run", envvar="DRY_RUN", is_flag=True)
-def _cli(target, source, signature_type, host, port, debug, dry_run):
+@click.option("--options", "-o", envvar="OPTIONS", multiple=True)
+def _cli(target, source, signature_type, host, port, debug, dry_run, options):
     app = create_app(target, source, signature_type)
     if dry_run:
         click.echo("Function: {}".format(target))
         click.echo("URL: http://{}:{}/".format(host, port))
         click.echo("Dry run successful, shutting down.")
     else:
-        create_server(app, debug).run(host, port)
+        server_options = {
+            option.split(":")[0]: option.split(":")[1] for option in options
+        }
+        create_server(app, debug, **server_options).run(host, port)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,12 @@ def test_cli_no_arguments():
             [pretend.call("foo", None, "http")],
             [pretend.call("0.0.0.0", 8080)],
         ),
+        (
+            ["--target", "foo", "--option", "workers:2", "--option", "threads:2"],
+            {},
+            [pretend.call("foo", None, "http")],
+            [pretend.call("0.0.0.0", 8080, {"workers": 2, "threads": 2})],
+        ),
     ],
 )
 def test_cli(monkeypatch, args, env, create_app_calls, run_calls):


### PR DESCRIPTION
Addressing #174 

Pass in options to be used to override defaults in the HTTP Server. Options should be in the format `"KEY:VALUE"`. For example `--options="workers:3" --options="thread:9"` will set the default workers to 3 and threads to 9. If using the Environment variable, then make sure multiple options are seprated by a whitespace.