### PR TITLE
fix: Add functools.wraps decorator

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -95,6 +95,7 @@ def setup_logging():
 
 
 def _http_view_func_wrapper(function, request):
+    @functools.wraps(function)
     def view_func(path):
         return function(request._get_current_object())
 

--- a/tests/test_view_functions.py
+++ b/tests/test_view_functions.py
@@ -31,6 +31,17 @@ def test_http_view_func_wrapper():
     assert function.calls == [pretend.call(request_object)]
 
 
+def test_http_view_func_wrapper_attribute_copied():
+    def function(_):
+        pass
+
+    function.attribute = "foo"
+    view_func = functions_framework._http_view_func_wrapper(function, pretend.stub())
+
+    assert view_func.__name__ == "function"
+    assert view_func.attribute == "foo"
+
+
 def test_event_view_func_wrapper(monkeypatch):
     data = pretend.stub()
     json = {


### PR DESCRIPTION
To make sure function attributes are copied to `_http_view_func_wrapper`

<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
