### PR TITLE
chore: use Release Please app for releases

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,2 @@
+releaseType: python
+handleGHRelease: true


### PR DESCRIPTION
This also handles bumping the version number in `setup.py` so that a separate
PR doesn't need to made.

When the GitHub Release is published by the Release Please app, it will
kick off the "Release to PyPI" Workflow.

<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
