### PR TITLE
feat: allow for watchdog>=2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "flask>=1.0,<3.0",
         "click>=7.0,<9.0",
-        "watchdog>=1.0.0,<2.0.0",
+        "watchdog>=1.0.0",
         "gunicorn>=19.2.0,<21.0; platform_system!='Windows'",
         "cloudevents>=1.2.0,<2.0.0",
     ],


### PR DESCRIPTION
`mkdocs>=1.2.2` [depends on](https://github.com/mkdocs/mkdocs/blob/cdf8a26cafa6af6cc78a45766dfec235bd7286cc/setup.py#L69) `watchdog>=2.0` and the restriction of watchdog dependency for functions-framework-python done in #101 seems to be due [an issue related to watchdog built distributions](https://github.com/gorakhargosh/watchdog/issues/689#issuecomment-748241552) (as explained by @di) which is [now fixed](https://github.com/gorakhargosh/watchdog/pull/807).

I propose to allow for `watchdog>=2.0.0` so that a project can use both `mkdocs>=1.2.2` (or `watchdog>=2.0.0`) and `functions-framework-python>=3.0.0`.