### PR TITLE
chore: add more pytypes

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -19,7 +19,6 @@ import logging
 import os.path
 import pathlib
 import sys
-from typing import Any, Callable
 
 import cloudevents.exceptions as cloud_exceptions
 import flask
@@ -35,6 +34,7 @@ from functions_framework.exceptions import (
     MissingSourceException,
 )
 from google.cloud.functions.context import Context
+from typing import Any, Callable
 
 MAX_CONTENT_LENGTH = 10 * 1024 * 1024
 

--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -21,7 +21,6 @@ import pathlib
 import sys
 from typing import Any, Callable
 
-
 import cloudevents.exceptions as cloud_exceptions
 import flask
 import werkzeug

--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -20,6 +20,8 @@ import os.path
 import pathlib
 import sys
 
+from typing import Any, Callable
+
 import cloudevents.exceptions as cloud_exceptions
 import flask
 import werkzeug
@@ -34,7 +36,6 @@ from functions_framework.exceptions import (
     MissingSourceException,
 )
 from google.cloud.functions.context import Context
-from typing import Any, Callable
 
 MAX_CONTENT_LENGTH = 10 * 1024 * 1024
 

--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -19,6 +19,8 @@ import logging
 import os.path
 import pathlib
 import sys
+from typing import Any, Callable
+
 
 import cloudevents.exceptions as cloud_exceptions
 import flask
@@ -56,7 +58,7 @@ class _LoggingHandler(io.TextIOWrapper):
         return self.stderr.write(json.dumps(payload) + "\n")
 
 
-def cloud_event(func):
+def cloud_event(func: Any) -> Callable[[Any, Any], Any]:
     """Decorator that registers cloudevent as user function signature type."""
     _function_registry.REGISTRY_MAP[
         func.__name__
@@ -69,7 +71,7 @@ def cloud_event(func):
     return wrapper
 
 
-def http(func):
+def http(func: Any) -> Callable[[Any, Any], Any]:
     """Decorator that registers http as user function signature type."""
     _function_registry.REGISTRY_MAP[
         func.__name__
@@ -176,7 +178,7 @@ def _event_view_func_wrapper(function, request):
     return view_func
 
 
-def _configure_app(app, function, signature_type):
+def _configure_app(app: Any, function: Any, signature_type: str) -> None:
     # Mount the function at the root. Support GCF's default path behavior
     # Modify the url_map and view_functions directly here instead of using
     # add_url_rule in order to create endpoints that route all methods

--- a/src/functions_framework/_function_registry.py
+++ b/src/functions_framework/_function_registry.py
@@ -16,12 +16,13 @@ import os
 import sys
 import types
 
+from typing import Dict
+
 from functions_framework.exceptions import (
     InvalidConfigurationException,
     InvalidTargetTypeException,
     MissingTargetException,
 )
-from typing import Dict
 
 DEFAULT_SOURCE = os.path.realpath("./main.py")
 

--- a/src/functions_framework/_function_registry.py
+++ b/src/functions_framework/_function_registry.py
@@ -15,13 +15,13 @@ import importlib.util
 import os
 import sys
 import types
-from typing import Dict
 
 from functions_framework.exceptions import (
     InvalidConfigurationException,
     InvalidTargetTypeException,
     MissingTargetException,
 )
+from typing import Dict
 
 DEFAULT_SOURCE = os.path.realpath("./main.py")
 

--- a/src/functions_framework/_function_registry.py
+++ b/src/functions_framework/_function_registry.py
@@ -15,6 +15,7 @@ import importlib.util
 import os
 import sys
 import types
+from typing import Dict
 
 from functions_framework.exceptions import (
     InvalidConfigurationException,
@@ -31,7 +32,7 @@ BACKGROUNDEVENT_SIGNATURE_TYPE = "event"
 
 # REGISTRY_MAP stores the registered functions.
 # Keys are user function names, values are user function signature types.
-REGISTRY_MAP = {}
+REGISTRY_MAP: Dict[str, str] = {}
 
 
 def get_user_function(source, source_module, target):
@@ -108,8 +109,8 @@ def get_func_signature_type(func_name: str, signature_type: str) -> str:
         3. environment variable FUNCTION_SIGNATURE_TYPE
     If none of the above is set, signature type defaults to be "http".
     """
-    registered_type = REGISTRY_MAP[func_name] if func_name in REGISTRY_MAP else ""
-    sig_type = (
+    registered_type: str = REGISTRY_MAP[func_name] if func_name in REGISTRY_MAP else ""
+    sig_type: str = (
         registered_type
         or signature_type
         or os.environ.get(FUNCTION_SIGNATURE_TYPE, HTTP_SIGNATURE_TYPE)


### PR DESCRIPTION
Adds a few more pytypes. We should figure out a way to add more automatically.

See https://github.com/GoogleCloudPlatform/functions-framework-python/issues/190

```
python -m tox -e lint
.tox/lint/bin/black tests
python3 ~/Library/Python/3.8/lib/python/site-packages/mypy/__main__.py src/functions_framework/__init__.py
```