### PR TITLE
feat: configurable MAX_CONTENT_LENGTH

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -35,7 +35,7 @@ from functions_framework.exceptions import (
 )
 from google.cloud.functions.context import Context
 
-MAX_CONTENT_LENGTH = 10 * 1024 * 1024
+DEFAULT_MAX_CONTENT_LENGTH = 10 * 1024 * 1024
 
 _FUNCTION_STATUS_HEADER_FIELD = "X-Google-Status"
 _CRASH = "crash"
@@ -262,7 +262,10 @@ def create_app(target=None, source=None, signature_type=None):
 
     # Create the application
     _app = flask.Flask(target, template_folder=template_folder)
-    _app.config["MAX_CONTENT_LENGTH"] = MAX_CONTENT_LENGTH
+    try:
+        _app.config["MAX_CONTENT_LENGTH"] = int(os.environ.get("HTTP_MAX_CONTENT_LENGTH"))
+    except:
+        _app.config["MAX_CONTENT_LENGTH"] = DEFAULT_MAX_CONTENT_LENGTH
     _app.register_error_handler(500, crash_handler)
     global errorhandler
     errorhandler = _app.errorhandler

--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -35,7 +35,7 @@ from functions_framework.exceptions import (
 )
 from google.cloud.functions.context import Context
 
-DEFAULT_MAX_CONTENT_LENGTH = 10 * 1024 * 1024
+DEFAULT_MAX_CONTENT_LENGTH = 1000 * 1024 * 1024
 
 _FUNCTION_STATUS_HEADER_FIELD = "X-Google-Status"
 _CRASH = "crash"

--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -263,7 +263,9 @@ def create_app(target=None, source=None, signature_type=None):
     # Create the application
     _app = flask.Flask(target, template_folder=template_folder)
     try:
-        _app.config["MAX_CONTENT_LENGTH"] = int(os.environ.get("HTTP_MAX_CONTENT_LENGTH"))
+        _app.config["MAX_CONTENT_LENGTH"] = int(
+            os.environ.get("HTTP_MAX_CONTENT_LENGTH")
+        )
     except:
         _app.config["MAX_CONTENT_LENGTH"] = DEFAULT_MAX_CONTENT_LENGTH
     _app.register_error_handler(500, crash_handler)


### PR DESCRIPTION
This PR implements #113.
One can configure the limit by setting the environment variable `HTTP_MAX_CONTENT_LENGTH`.

What's more, it seems reasonable to make the default value of `MAX_CONTENT_LENGTH` higher, just like the one in Node.js implementation of functions-framework.
See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/6e7431828a4fbb4aadcd6acab62f97e62bd776ab/src/server.ts#L62-L64