### PR TITLE
fix: remove DRY_RUN env var and --dry-run flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,6 @@ You can configure the Functions Framework using command-line flags or environmen
 | `--signature-type` | `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Default: `http`; accepted values: `http`, `event` or `cloudevent` |
 | `--source`         | `FUNCTION_SOURCE`         | The path to the file containing your function. Default: `main.py` (in the current working directory)                                                                                             |
 | `--debug`          | `DEBUG`                   | A flag that allows to run functions-framework to run in debug mode, including live reloading. Default: `False`                                                                                   |
-| `--dry-run`        | `DRY_RUN`                 | A flag that allows for testing the function build from the configuration without creating a server. Default: `False` |
 
 ## Enable Google Cloud Function Events
 

--- a/src/functions_framework/_cli.py
+++ b/src/functions_framework/_cli.py
@@ -32,12 +32,6 @@ from functions_framework._http import create_server
 @click.option("--host", envvar="HOST", type=click.STRING, default="0.0.0.0")
 @click.option("--port", envvar="PORT", type=click.INT, default=8080)
 @click.option("--debug", envvar="DEBUG", is_flag=True)
-@click.option("--dry-run", envvar="DRY_RUN", is_flag=True)
-def _cli(target, source, signature_type, host, port, debug, dry_run):
+def _cli(target, source, signature_type, host, port, debug):
     app = create_app(target, source, signature_type)
-    if dry_run:
-        click.echo("Function: {}".format(target))
-        click.echo("URL: http://{}:{}/".format(host, port))
-        click.echo("Dry run successful, shutting down.")
-    else:
-        create_server(app, debug).run(host, port)
+    create_server(app, debug).run(host, port)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,18 +70,6 @@ def test_cli_no_arguments():
             [pretend.call("0.0.0.0", 8080)],
         ),
         (
-            ["--target", "foo", "--dry-run"],
-            {},
-            [pretend.call("foo", None, "http")],
-            [],
-        ),
-        (
-            [],
-            {"FUNCTION_TARGET": "foo", "DRY_RUN": "True"},
-            [pretend.call("foo", None, "http")],
-            [],
-        ),
-        (
             ["--target", "foo", "--host", "127.0.0.1"],
             {},
             [pretend.call("foo", None, "http")],


### PR DESCRIPTION
Free the DRY_RUN env var name to be used for other purposes by function authors.

The original intent of the DRY_RUN was to be used at build time for GCF to validate function syntax without starting the server, but this was never implemented. For local testing purposes, simply starting the functions framework server is a better method.

<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
