### PR TITLE
fix: don't exit on reload if there is a syntax error

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -359,12 +359,15 @@ def create_app(target=None, source=None, signature_type=None):
     with _app.app_context():
         try:
             spec.loader.exec_module(source_module)
-            function = _function_registry.get_user_function(source, source_module, target)
+            function = _function_registry.get_user_function(
+                source, source_module, target
+            )
         except Exception as e:
             if werkzeug.serving.is_running_from_reloader():
                 # When reloading, print out the error immediately, but raise
                 # it later so the debugger or server can handle it.
                 import traceback
+
                 traceback.print_exc()
                 err = e
 

--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -357,11 +357,27 @@ def create_app(target=None, source=None, signature_type=None):
 
     # Execute the module, within the application context
     with _app.app_context():
-        spec.loader.exec_module(source_module)
+        try:
+            spec.loader.exec_module(source_module)
+            function = _function_registry.get_user_function(source, source_module, target)
+        except Exception as e:
+            if werkzeug.serving.is_running_from_reloader():
+                # When reloading, print out the error immediately, but raise
+                # it later so the debugger or server can handle it.
+                import traceback
+                traceback.print_exc()
+                err = e
+
+                def function(*_args, **_kwargs):
+                    raise err from None
+
+            else:
+                # When not reloading, raise the error immediately so the
+                # command fails.
+                raise e from None
 
     # Get the configured function signature type
     signature_type = _function_registry.get_func_signature_type(target, signature_type)
-    function = _function_registry.get_user_function(source, source_module, target)
 
     _configure_app(_app, function, signature_type)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -323,6 +323,19 @@ def test_invalid_function_definition_function_syntax_error():
     )
 
 
+def test_invalid_function_definition_function_syntax_robustness_with_debug(monkeypatch):
+    monkeypatch.setattr(
+        functions_framework.werkzeug.serving, "is_running_from_reloader", lambda: True
+    )
+    source = TEST_FUNCTIONS_DIR / "background_load_error" / "main.py"
+    target = "function"
+
+    client = create_app(target, source).test_client()
+
+    resp = client.get("/")
+    assert resp.status_code == 500
+
+
 def test_invalid_function_definition_missing_dependency():
     source = TEST_FUNCTIONS_DIR / "background_missing_dependency" / "main.py"
     target = "function"


### PR DESCRIPTION
fixes #213 


Now, if you introduce a syntax error, you immediately get:

```
 * Detected change in '/Users/david/src/opvia/app/scripts_v3/cloud_function/main.py', reloading
 * Restarting with watchdog (fsevents)
Traceback (most recent call last):
  File "/Users/david/src/opvia/app/.venv/lib/python3.10/site-packages/functions_framework/__init__.py", line 290, in create_app
    spec.loader.exec_module(source_module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/david/src/opvia/app/scripts_v3/cloud_function/main.py", line 11
    ///
    ^^
SyntaxError: invalid syntax
 * Debugger is active!
 * Debugger PIN: 104-682-644
```

and then if you curl your fuction endpoint, you get the debug html page for the syntax error, and the backtrace gets printed out to stderr again.

If you attempt to *start* the server when there is already a syntax error present, it correctly exits with the error, as before (the only difference being that the backtrace points at the `raise e from None` line rather than the `spec.loader.exec_module(source_module)` line). 

This behaviour matches the upstream `flask run` behaviour now.

Feel free to be brutal about the quality of my python code: the last time I wrote significant production python, it was before python 2.7 was deprecated ;-) 