### PR TITLE
chore: update unit tests with headers

### DIFF
--- a/tests/test_cloud_event_functions.py
+++ b/tests/test_cloud_event_functions.py
@@ -187,7 +187,8 @@ def test_invalid_fields_binary(client, create_headers_binary, data_payload):
 
 
 def test_unparsable_cloud_event(client):
-    resp = client.post("/", headers={}, data="")
+    headers = {"Content-Type": "application/cloudevents+json"}
+    resp = client.post("/", headers=headers, data="")
 
     assert resp.status_code == 400
     assert "Bad Request" in resp.data.decode()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -251,7 +251,8 @@ def test_pubsub_payload(background_event_client, background_json):
 
 
 def test_background_function_no_data(background_event_client, background_json):
-    resp = background_event_client.post("/")
+    headers = {"Content-Type": "application/json"}
+    resp = background_event_client.post("/", headers=headers)
     assert resp.status_code == 400
 
 


### PR DESCRIPTION
Update unit tests to reflect changes from our dependencies: https://github.com/pallets/werkzeug/pull/2551

Without proper headers, `werkzeug` lib returns 415 error code instead of 400, which is what we're asserting in tests.

Fixes: https://github.com/GoogleCloudPlatform/functions-framework-python/issues/238