### PR TITLE
chore: add-endpoint-to-allowlist

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,7 @@ jobs:
             files.pythonhosted.org:443
             github.com:443
             pypi.org:443
+            objects.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
Action https://app.stepsecurity.io/github/GoogleCloudPlatform/functions-framework-python/actions/runs/5147464729 blocked a needed outbound call. Adding it to allowlist.