### PR TITLE
fix: reduce gunicorn concurrency to at most 4 * maximum available cor…

### DIFF
--- a/src/functions_framework/_http/gunicorn.py
+++ b/src/functions_framework/_http/gunicorn.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import gunicorn.app.base
 
 
@@ -20,7 +22,7 @@ class GunicornApplication(gunicorn.app.base.BaseApplication):
         self.options = {
             "bind": "%s:%s" % (host, port),
             "workers": 1,
-            "threads": 64,
+            "threads": (os.cpu_count() or 1) * 4,
             "timeout": 0,
             "loglevel": "error",
             "limit_request_line": 0,

--- a/src/functions_framework/_http/gunicorn.py
+++ b/src/functions_framework/_http/gunicorn.py
@@ -20,7 +20,7 @@ class GunicornApplication(gunicorn.app.base.BaseApplication):
         self.options = {
             "bind": "%s:%s" % (host, port),
             "workers": 1,
-            "threads": 1024,
+            "threads": 64,
             "timeout": 0,
             "loglevel": "error",
             "limit_request_line": 0,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import platform
 import sys
 
@@ -97,7 +98,7 @@ def test_gunicorn_application(debug):
     assert gunicorn_app.options == {
         "bind": "%s:%s" % (host, port),
         "workers": 1,
-        "threads": 1024,
+        "threads": os.cpu_count() * 4,
         "timeout": 0,
         "loglevel": "error",
         "limit_request_line": 0,
@@ -105,7 +106,7 @@ def test_gunicorn_application(debug):
 
     assert gunicorn_app.cfg.bind == ["1.2.3.4:1234"]
     assert gunicorn_app.cfg.workers == 1
-    assert gunicorn_app.cfg.threads == 1024
+    assert gunicorn_app.cfg.threads == os.cpu_count() * 4
     assert gunicorn_app.cfg.timeout == 0
     assert gunicorn_app.load() == app
 


### PR DESCRIPTION
Updates gunicorn's multithreading logic to derive the maximum concurrency the container can handle from the number of cores available to the functon. 4 invocations per core (given that memory additionally scales with cores) will be a good default concurrency limit that most functions will support without running into resource problems.