### PR TITLE
chore: Fix workflow duplication

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Python Lint CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 permissions:
   contents: read
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,5 +1,9 @@
 name: Python Unit CI
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 permissions:
   contents: read
 


### PR DESCRIPTION
Workflows using `on: [push, pull_request]` are being duplicated during pull requests wasting runner resources.
