### PR TITLE
chore(deps): remove gunicorn version upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "flask>=1.0,<3.0",
         "click>=7.0,<9.0",
         "watchdog>=1.0.0",
-        "gunicorn>=19.2.0,<21.0; platform_system!='Windows'",
+        "gunicorn>=19.2.0; platform_system!='Windows'",
         "cloudevents>=1.2.0,<2.0.0",
     ],
     entry_points={


### PR DESCRIPTION
Remove the upper version bound for Gunicorn to unblock fixes and python 3.11 support