### PR TITLE
 fix!: avoid long running process when request timeout

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -65,9 +65,9 @@ class _LoggingHandler(io.TextIOWrapper):
 
 def cloud_event(func: CloudEventFunction) -> CloudEventFunction:
     """Decorator that registers cloudevent as user function signature type."""
-    _function_registry.REGISTRY_MAP[
-        func.__name__
-    ] = _function_registry.CLOUDEVENT_SIGNATURE_TYPE
+    _function_registry.REGISTRY_MAP[func.__name__] = (
+        _function_registry.CLOUDEVENT_SIGNATURE_TYPE
+    )
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -105,9 +105,9 @@ def typed(*args):
 
 def http(func: HTTPFunction) -> HTTPFunction:
     """Decorator that registers http as user function signature type."""
-    _function_registry.REGISTRY_MAP[
-        func.__name__
-    ] = _function_registry.HTTP_SIGNATURE_TYPE
+    _function_registry.REGISTRY_MAP[func.__name__] = (
+        _function_registry.HTTP_SIGNATURE_TYPE
+    )
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/src/functions_framework/_http/gunicorn.py
+++ b/src/functions_framework/_http/gunicorn.py
@@ -21,14 +21,15 @@ class GunicornApplication(gunicorn.app.base.BaseApplication):
     def __init__(self, app, host, port, debug, **options):
         self.options = {
             "bind": "%s:%s" % (host, port),
-            "workers": 1,
-            "threads": (os.cpu_count() or 1) * 4,
-            "timeout": 0,
+            "workers": os.environ.get("WORKERS", (os.cpu_count() or 1) * 4),
+            "threads": os.environ.get("THREADS", 1),
+            "timeout": os.environ.get("CLOUD_RUN_TIMEOUT_SECONDS", 300),
             "loglevel": "error",
             "limit_request_line": 0,
         }
         self.options.update(options)
         self.app = app
+
         super().__init__()
 
     def load_config(self):

--- a/src/functions_framework/_typed_event.py
+++ b/src/functions_framework/_typed_event.py
@@ -48,9 +48,9 @@ def register_typed_event(decorator_type, func):
         )
 
     _function_registry.INPUT_TYPE_MAP[func.__name__] = input_type
-    _function_registry.REGISTRY_MAP[
-        func.__name__
-    ] = _function_registry.TYPED_SIGNATURE_TYPE
+    _function_registry.REGISTRY_MAP[func.__name__] = (
+        _function_registry.TYPED_SIGNATURE_TYPE
+    )
 
 
 """ Checks whether the response type of the typed function has a to_dict method"""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -97,17 +97,17 @@ def test_gunicorn_application(debug):
     assert gunicorn_app.app == app
     assert gunicorn_app.options == {
         "bind": "%s:%s" % (host, port),
-        "workers": 1,
-        "threads": os.cpu_count() * 4,
-        "timeout": 0,
+        "workers": os.cpu_count() * 4,
+        "threads": 1,
+        "timeout": 300,
         "loglevel": "error",
         "limit_request_line": 0,
     }
 
     assert gunicorn_app.cfg.bind == ["1.2.3.4:1234"]
-    assert gunicorn_app.cfg.workers == 1
-    assert gunicorn_app.cfg.threads == os.cpu_count() * 4
-    assert gunicorn_app.cfg.timeout == 0
+    assert gunicorn_app.cfg.workers == os.cpu_count() * 4
+    assert gunicorn_app.cfg.threads == 1
+    assert gunicorn_app.cfg.timeout == 300
     assert gunicorn_app.load() == app
 
 


### PR DESCRIPTION
     Previously function framework use 0 timeout which is actually "no timeout" restriction.
     This was causing a problem that when user provides a request timeout to Cloud function, process will still continue and consume resources.
     In this fix, timeout is enabled; default timeout settings is 5 min, same as Cloud run.
     To make sure timeout settings will be respected, default settings switched from multi-threads to multi-workers.
    
     However, user is still allowed to  customize workers/threads by assigning env var. But user need to note that timeout won't work when #thread > 1.




<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
