### PR TITLE
chore: Fix unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,6 +13,22 @@ jobs:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        # Python <= 3.9 is not available on macos-14
+        # Workaround for https://github.com/actions/setup-python/issues/696
+        exclude:
+        - os: macos-latest
+          python-version: '3.9'
+        - os: macos-latest
+          python-version: '3.8'
+        - os: macos-latest
+          python-version: '3.7'
+        include:
+        - os: macos-latest
+          python-version: '3.9'
+        - os: macos-13
+          python-version: '3.8'
+        - os: macos-13
+          python-version: '3.7'
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Harden Runner

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -16,18 +16,18 @@ jobs:
         # Python <= 3.9 is not available on macos-14
         # Workaround for https://github.com/actions/setup-python/issues/696
         exclude:
-        - os: macos-latest
+        - platform: macos-latest
           python-version: '3.9'
-        - os: macos-latest
+        - platform: macos-latest
           python-version: '3.8'
-        - os: macos-latest
+        - platform: macos-latest
           python-version: '3.7'
         include:
-        - os: macos-latest
+        - platform: macos-latest
           python-version: '3.9'
-        - os: macos-13
+        - platform: macos-13
           python-version: '3.8'
-        - os: macos-13
+        - platform: macos-13
           python-version: '3.7'
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,18 +17,18 @@ jobs:
         # Workaround for https://github.com/actions/setup-python/issues/696
         exclude:
         - platform: macos-latest
-          python-version: '3.9'
+          python: '3.9'
         - platform: macos-latest
-          python-version: '3.8'
+          python: '3.8'
         - platform: macos-latest
-          python-version: '3.7'
+          python: '3.7'
         include:
         - platform: macos-latest
-          python-version: '3.9'
+          python: '3.9'
         - platform: macos-13
-          python-version: '3.8'
+          python: '3.8'
         - platform: macos-13
-          python-version: '3.7'
+          python: '3.7'
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Harden Runner


### PR DESCRIPTION
Workaround for https://github.com/actions/setup-python/issues/696. macos-latest recently was updated to point to macos-14, which does not support Python 3.7, 3.8, 3.9 on ARM.

<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
