### PR TITLE
fix: remove unused import

### DIFF
--- a/src/functions_framework/_function_registry.py
+++ b/src/functions_framework/_function_registry.py
@@ -16,7 +16,6 @@ import os
 import sys
 import types
 
-from re import T
 from typing import Type
 
 from functions_framework.exceptions import (


### PR DESCRIPTION
Removed unused import `re.T` from _function_registry.py

Which was deprecated in [Python 3.13](https://docs.python.org/3/whatsnew/3.13.html#id5)

Which this package doesn't yet explicitly support, but when [creating a PR for this update](https://github.com/glasnt/functions-framework-python/pull/1), I ran into CI issues with [Python 3.13 being too new for setup-python cache](https://github.com/glasnt/functions-framework-python/actions/runs/11376121925/job/31648168174) (which [resolved when removing the harden-runner](https://github.com/glasnt/functions-framework-python/actions/runs/11376283257/job/31648499294), but then there are larger issues [most buildpack-integration tests failing](https://github.com/glasnt/functions-framework-python/actions/runs/11376283279/job/31648505573))

Detected in https://github.com/GoogleCloudPlatform/cloud-run-samples/pull/260