### PR TITLE
fix: Avoid potentially problematic flask release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "flask>=2.0,<4.0",
+  "flask>=2.0,<4.0,!=3.1.1",
   "click>=7.0,<9.0",
   "watchdog>=1.0.0",
   "gunicorn>=22.0.0; platform_system!='Windows'",


### PR DESCRIPTION
The conformance tests are failing, and the only significant change is that a new version of Flask was recently release. Try skipping it as a supdependency to determine if this is the cause.