### PR TITLE
fix: drop support for Python 3.7

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,8 +17,6 @@ jobs:
         include:
           - platform: ubuntu-22.04
             python: '3.8'
-          - platform: ubuntu-22.04
-            python: '3.7'
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Harden Runner

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         platform: [ubuntu-latest, macos-latest, windows-latest]
         # Python <= 3.9 is not available on macos-latest
         # Workaround for https://github.com/actions/setup-python/issues/696
@@ -21,23 +21,15 @@ jobs:
           python: '3.9'
         - platform: macos-latest
           python: '3.8'
-        - platform: macos-latest
-          python: '3.7'
         - platform: ubuntu-latest
           python: '3.8'
-        - platform: ubuntu-latest
-          python: '3.7'
         include:
         - platform: macos-latest
           python: '3.9'
         - platform: macos-13
           python: '3.8'
-        - platform: macos-13
-          python: '3.7'
         - platform: ubuntu-22.04
           python: '3.8'
-        - platform: ubuntu-22.04
-          python: '3.7'
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Harden Runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "functions-framework"
 version = "3.8.3"
 description = "An open source FaaS (Function as a service) framework for writing portable Python functions -- brought to you by the Google Cloud Functions team."
 readme = "README.md"
-requires-python = ">=3.5, <4"
+requires-python = ">=3.8, <4"
 # Once we drop support for Python 3.7 and 3.8, this can become
 # license = "Apache-2.0"
 license = {text = "Apache-2.0"}
@@ -17,7 +17,6 @@ keywords = ["functions-framework"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,6 @@ envlist =
     py38-ubuntu-22.04
     py38-macos-13
     py38-windows-latest
-    py37-ubuntu-22.04
-    py37-macos-13
-    py37-windows-latest
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
Python 3.7 reached end-of-life in June 2023 and is no longer supported by Google Cloud. This commit removes all references to Python 3.7 from:

- tox.ini test environments
- pyproject.toml requirements and classifiers
- GitHub Actions workflows (unit.yml and conformance.yml)