### PR TITLE
fix: Pin cloudevent sdk version to support python3.7.

### DIFF
--- a/examples/cloud_run_cloud_events/requirements.txt
+++ b/examples/cloud_run_cloud_events/requirements.txt
@@ -1,3 +1,3 @@
 # Optionally include additional dependencies here
-cloudevents==1.11.0
+cloudevents==1.11.0  # Pin version - last version compatible w/ python3.7
 requests

--- a/examples/cloud_run_cloud_events/requirements.txt
+++ b/examples/cloud_run_cloud_events/requirements.txt
@@ -1,3 +1,3 @@
 # Optionally include additional dependencies here
-cloudevents>=1.2.0
+cloudevents==1.11.0
 requests

--- a/examples/cloud_run_decorator/requirements.txt
+++ b/examples/cloud_run_decorator/requirements.txt
@@ -1,2 +1,2 @@
 # Optionally include additional dependencies here
-cloudevents==1.11.0
+cloudevents==1.11.0  # Pin version - last version compatible w/ python3.7

--- a/examples/cloud_run_decorator/requirements.txt
+++ b/examples/cloud_run_decorator/requirements.txt
@@ -1,1 +1,2 @@
 # Optionally include additional dependencies here
+cloudevents==1.11.0

--- a/examples/cloud_run_event/requirements.txt
+++ b/examples/cloud_run_event/requirements.txt
@@ -1,2 +1,2 @@
 # Optionally include additional dependencies here
-cloudevents==1.11.0
+cloudevents==1.11.0  # Pin version - last version compatible w/ python3.7

--- a/examples/cloud_run_event/requirements.txt
+++ b/examples/cloud_run_event/requirements.txt
@@ -1,1 +1,2 @@
 # Optionally include additional dependencies here
+cloudevents==1.11.0

--- a/examples/cloud_run_http/requirements.txt
+++ b/examples/cloud_run_http/requirements.txt
@@ -1,2 +1,2 @@
 # Optionally include additional dependencies here
-cloudevents==1.11.0
+cloudevents==1.11.0  # Pin version - last version compatible w/ python3.7

--- a/examples/cloud_run_http/requirements.txt
+++ b/examples/cloud_run_http/requirements.txt
@@ -1,1 +1,2 @@
 # Optionally include additional dependencies here
+cloudevents==1.11.0

--- a/examples/docker-compose/requirements.txt
+++ b/examples/docker-compose/requirements.txt
@@ -1,1 +1,2 @@
 # Add any Python requirements here
+cloudevents==1.11.0

--- a/examples/docker-compose/requirements.txt
+++ b/examples/docker-compose/requirements.txt
@@ -1,2 +1,2 @@
 # Add any Python requirements here
-cloudevents==1.11.0
+cloudevents==1.11.0  # Pin version - last version compatible w/ python3.7

--- a/examples/skaffold/requirements.txt
+++ b/examples/skaffold/requirements.txt
@@ -1,1 +1,2 @@
 # Add any Python requirements here
+cloudevents==1.11.0

--- a/examples/skaffold/requirements.txt
+++ b/examples/skaffold/requirements.txt
@@ -1,2 +1,2 @@
 # Add any Python requirements here
-cloudevents==1.11.0
+cloudevents==1.11.0  # Pin version - last version compatible w/ python3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,10 @@ readme = "README.md"
 requires-python = ">=3.5, <4"
 # Once we drop support for Python 3.7 and 3.8, this can become
 # license = "Apache-2.0"
-license = {text = "Apache-2.0"}
-authors = [
-  { name = "Google LLC", email = "googleapis-packages@google.com" }
-]
+license = { text = "Apache-2.0" }
+authors = [{ name = "Google LLC", email = "googleapis-packages@google.com" }]
 maintainers = [
-  { name = "Google LLC", email = "googleapis-packages@google.com" }
+  { name = "Google LLC", email = "googleapis-packages@google.com" },
 ]
 keywords = ["functions-framework"]
 classifiers = [
@@ -29,7 +27,7 @@ dependencies = [
   "click>=7.0,<9.0",
   "watchdog>=1.0.0",
   "gunicorn>=22.0.0; platform_system!='Windows'",
-  "cloudevents>=1.2.0,<2.0.0",
+  "cloudevents>=1.2.0,<=1.11.0",                  # Must support python 3.7
   "Werkzeug>=0.14,<4.0.0",
 ]
 


### PR DESCRIPTION
Cloudevent SDK implicitly (https://github.com/cloudevents/sdk-python/releases/tag/1.11.1) and then explicitly (https://github.com/cloudevents/sdk-python/releases/tag/1.12.0) dropped support for Python 3.8 and below.

We pin the cloudevent version in functions framework to continue to support python37 and python38 runtimes.
