### PR TITLE
fix(ci): specify python version in tox environment

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -64,6 +64,7 @@ jobs:
     - name: Install tox
       run: python -m pip install tox
     - name: Test
+      shell: bash
       run: |
         # Remove dots from python version string, i.e. 3.10 -> 310
         PY_VERSION=$(echo "${{ matrix.python }}" | sed 's/\.//g')


### PR DESCRIPTION
This is necessary for us to specify different pytest arg for deprecated but still supported runtimes, like py37.