### PR TITLE
fix: set ASGI logging level to WARNING to match WSGI behavior

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -437,7 +437,7 @@ def _configure_app_execution_id_logging():
                     "stream": "ext://functions_framework.execution_id.logging_stream",
                 },
             },
-            "root": {"level": "INFO", "handlers": ["wsgi"]},
+            "root": {"level": "WARNING", "handlers": ["wsgi"]},
         }
     )
 

--- a/src/functions_framework/aio/__init__.py
+++ b/src/functions_framework/aio/__init__.py
@@ -172,7 +172,7 @@ def _configure_app_execution_id_logging():
                     "stream": "ext://functions_framework.execution_id.logging_stream",
                 },
             },
-            "root": {"level": "INFO", "handlers": ["asgi"]},
+            "root": {"level": "WARNING", "handlers": ["asgi"]},
         }
     )
 


### PR DESCRIPTION
ASGI logger defaults to `INFO` instead of `WARNING` which is the default for Python.