### PR TITLE
feat: support asgi frameworks directly in asgi mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ functions_framework = ["py.typed"]
 dev = [
     "black>=23.3.0",
     "build>=1.1.1",
+    "fastapi>=0.100.0",
     "isort>=5.11.5",
     "pretend>=1.0.9",
     "pytest>=7.4.4",

--- a/tests/test_functions/asgi_apps/bare_asgi.py
+++ b/tests/test_functions/asgi_apps/bare_asgi.py
@@ -1,0 +1,16 @@
+async def app(scope, receive, send):
+    assert scope["type"] == "http"
+
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": b"Hello from ASGI",
+        }
+    )

--- a/tests/test_functions/asgi_apps/fastapi_app.py
+++ b/tests/test_functions/asgi_apps/fastapi_app.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+
+
+@app.get("/items/{item_id}")
+async def read_item(item_id: int):
+    return {"item_id": item_id}

--- a/tests/test_functions/asgi_apps/starlette_app.py
+++ b/tests/test_functions/asgi_apps/starlette_app.py
@@ -1,0 +1,14 @@
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+async def homepage(request):
+    return JSONResponse({"message": "Hello from Starlette"})
+
+
+app = Starlette(
+    routes=[
+        Route("/", homepage),
+    ]
+)

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     pytest-cov
     pytest-integration
     pretend
+    py,py38,py39,py310,py311,py312: fastapi
 extras =
     async
 setenv =
@@ -48,8 +49,6 @@ deps =
     isort
     mypy
     build
-extras =
-    async
 commands =
     black --check src tests conftest.py --exclude tests/test_functions/background_load_error/main.py
     isort -c src tests conftest.py


### PR DESCRIPTION
This PR enables the Functions Framework to automatically detect and run ASGI web frameworks like FastAPI and Starlette. When the framework detects an ASGI app, functions framework handles the set up without requiring any special configuration.

This allows developers to easily deploy modern Python web frameworks with their full feature set (routing, middleware, validation) to Cloud Run functions.


```python
from fastapi import FastAPI

app = FastAPI()

@app.get("/")
def read_root():
    return {"message": "Hello World"}

@app.get("/items/{item_id}")
def read_item(item_id: int):
    return {"item_id": item_id}
```
 
Load the app in functions framework:

```bash
functions-framework --target app --asgi
```
