### PR TITLE
refactor: replace --gateway flag with --asgi boolean flag

### DIFF
--- a/src/functions_framework/_cli.py
+++ b/src/functions_framework/_cli.py
@@ -33,14 +33,13 @@ from functions_framework._http import create_server
 @click.option("--port", envvar="PORT", type=click.INT, default=8080)
 @click.option("--debug", envvar="DEBUG", is_flag=True)
 @click.option(
-    "--gateway",
-    envvar="FUNCTION_GATEWAY",
-    type=click.Choice(["wsgi", "asgi"]),
-    default="wsgi",
-    help="Server gateway interface type (wsgi for sync, asgi for async)",
+    "--asgi",
+    envvar="FUNCTION_USE_ASGI",
+    is_flag=True,
+    help="Use ASGI server for function execution",
 )
-def _cli(target, source, signature_type, host, port, debug, gateway):
-    if gateway == "asgi":  # pragma: no cover
+def _cli(target, source, signature_type, host, port, debug, asgi):
+    if asgi:  # pragma: no cover
         from functions_framework.aio import create_asgi_app
 
         app = create_asgi_app(target, source, signature_type)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,7 +119,7 @@ def test_asgi_cli(monkeypatch):
     monkeypatch.setattr(functions_framework._cli, "create_server", create_server)
 
     runner = CliRunner()
-    result = runner.invoke(_cli, ["--target", "foo", "--gateway", "asgi"])
+    result = runner.invoke(_cli, ["--target", "foo", "--asgi"])
 
     assert result.exit_code == 0
     assert create_asgi_app.calls == [pretend.call("foo", None, "http")]


### PR DESCRIPTION
## Summary
Replace `--gateway asgi` with `--asgi` flag for simpler CLI interface.

## Test plan
- [x] lint: `uv run tox -e lint`
- [x] tests: `uv run tox -e py`