### PR TITLE
fix: remove unused httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "gunicorn>=22.0.0; platform_system!='Windows'",
   "cloudevents>=1.2.0,<=1.11.0",                  # Must support python 3.7
   "Werkzeug>=0.14,<4.0.0",
-  "httpx>=0.24.1",
   "starlette>=0.37.0,<1.0.0; python_version>='3.8'",
   "uvicorn>=0.18.0,<1.0.0; python_version>='3.8'",
   "uvicorn-worker>=0.2.0,<1.0.0; python_version>='3.8'",


### PR DESCRIPTION
## Summary
This PR removes the `httpx` dependency that was accidentally added in #364 but is never used in the codebase.

## Context
While investigating our dependency growth, I discovered that `httpx` was added as a direct dependency but is not imported or used anywhere in the functions-framework codebase. This single dependency brought in 7 additional transitive dependencies.

## Impact
**Before this PR (28 packages):**
- Direct deps: 10 (including unused httpx)
- Package size: ~29MB

**After this PR (20 packages):**
- Direct deps: 9 (only what we actually use)
- Package size: ~27MB
- **Removes 8 packages**: httpx, anyio, httpcore, h11, certifi, idna, sniffio, typing_extensions

## Dependency Analysis
From the last release to current:
- Original: 17 packages
- Added async support: +3 packages (starlette, uvicorn, uvicorn-worker)
- Accidentally added httpx: +8 packages
- Total: 28 packages

With this fix, we're back to the expected 20 packages (17 + 3 async).

## Test Plan
All existing tests pass. The httpx package was never used, so its removal has no functional impact.