### PR TITLE
fix(ci): Add release-assets.githubusercontent.com to allowed endpoints

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,7 @@ jobs:
             github.com:443
             pypi.org:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The CodeQL workflow was failing because the `step-security/harden-runner` was blocking egress traffic to the endpoint used for downloading the CodeQL bundle.

The download from `https://github.com/github/codeql-action/releases` redirects to `release-assets.githubusercontent.com`.

This change adds `release-assets.githubusercontent.com` to the list of allowed endpoints to resolve the `ECONNREFUSED` error and removes previous incorrect attempts.