### PR TITLE
chore: remove macos-13 from test matrix (runner retired)

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,8 +26,6 @@ jobs:
         include:
         - platform: macos-latest
           python: '3.9'
-        - platform: macos-13
-          python: '3.8'
         - platform: ubuntu-22.04
           python: '3.8'
     runs-on: ${{ matrix.platform }}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ envlist =
     py39-macos-13
     py39-windows-latest
     py38-ubuntu-22.04
-    py38-macos-13
     py38-windows-latest
 
 [testenv]


### PR DESCRIPTION
Remove `macos-13` + Python 3.8 from the unit test matrix.

GitHub fully retired the `macos-13` runner image in December 2025 (actions/runner-images#13046), causing the `test (macos-13, 3.8)` job to fail with "The configuration 'macos-13-us-default' is not supported". Python 3.8 itself reached EOL in October 2024.

Python 3.8 is still tested on `ubuntu-22.04` and `windows-latest`.