### PR TITLE
test: validate resolve-latest fix from conformance repo

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -48,7 +48,7 @@ jobs:
       builder-runtime-version: '3.10'
       start-delay: 5
   python311:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@main
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@fix-resolve-latest
     with:
       http-builder-source: 'tests/conformance'
       http-builder-target: 'write_http_declarative'
@@ -58,6 +58,7 @@ jobs:
       builder-runtime: 'python311'
       builder-runtime-version: '3.11'
       start-delay: 5
+      conformance-action-version: 'fix-resolve-latest'
 # Python 3.12 conformance tests are disabled due to the buildpack defaulting to
 # Ubuntu 18.04, which has no Python 3.12 version, and being unable to specify
 # the OS/stack via the conformance test configuration


### PR DESCRIPTION
Test PR - points python311 buildpack job at conformance repo's `fix-resolve-latest` branch to validate that the `go list -m` based version resolution works correctly with `conformance-client-version: latest`.

See: https://github.com/GoogleCloudPlatform/functions-framework-conformance/pull/207

Do not merge.