### PR TITLE
fix(deps): bump starlette to >=1.0.1 on Python 3.10+ to fix PYSEC-202…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
   "gunicorn>=22.0.0; platform_system!='Windows'",
   "cloudevents>=1.11.0,<=1.12.0",                   # Must support python 3.8
   "Werkzeug>=0.14,<4.0.0",
-  "starlette>=0.37.0,<1.0.0; python_version>='3.8'",
+  "starlette>=0.37.0,<1.0.0; python_version>='3.8' and python_version<'3.10'",
+  "starlette>=1.0.1,<2.0.0; python_version>='3.10'",
   "uvicorn>=0.18.0,<1.0.0; python_version>='3.8'",
   "uvicorn-worker>=0.2.0,<1.0.0; python_version>='3.8'",
 ]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,10 @@ setup(
         "Werkzeug>=0.14,<4.0.0",
     ],
     extras_require={
-        "async": ["starlette>=0.37.0,<1.0.0"],
+        "async": [
+            "starlette>=0.37.0,<1.0.0; python_version<'3.10'",
+            "starlette>=1.0.1,<2.0.0; python_version>='3.10'",
+        ],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
…6-161

Starlette <=1.0.0 is vulnerable to a missing Host header validation that poisons request.url.path and bypasses path-based security checks (GHSA-86qp-5c8j-p5mr / PYSEC-2026-161). The fix only landed in 1.0.1, which requires Python >=3.10.

Constraint is split by interpreter version so Python 3.8/3.9 users keep the existing 0.x line (no upstream fix available) while Python 3.10+ pulls the patched 1.x line.

<!--

Before submitting a pull request:

Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.

-->
