### PR TITLE
fix: preserve user function type through http and cloud_event decorators

### DIFF
--- a/src/functions_framework/__init__.py
+++ b/src/functions_framework/__init__.py
@@ -25,7 +25,7 @@ import sys
 import types
 
 from inspect import signature
-from typing import Callable, Type
+from typing import Callable, Type, TypeVar
 
 import cloudevents.exceptions as cloud_exceptions
 import flask
@@ -56,6 +56,11 @@ _CLOUDEVENT_MIME_TYPE = "application/cloudevents+json"
 CloudEventFunction = Callable[[CloudEvent], None]
 HTTPFunction = Callable[[flask.Request], flask.typing.ResponseReturnValue]
 
+# TypeVars used by decorators to preserve the user function's exact type, so
+# that type checkers (mypy, pyright) can still verify call sites after decoration.
+_CloudEventFunctionT = TypeVar("_CloudEventFunctionT", bound=CloudEventFunction)
+_HTTPFunctionT = TypeVar("_HTTPFunctionT", bound=HTTPFunction)
+
 
 class _LoggingHandler(io.TextIOWrapper):
     """Logging replacement for stdout and stderr in GCF Python 3.7."""
@@ -70,7 +75,7 @@ class _LoggingHandler(io.TextIOWrapper):
         return self.stderr.write(json.dumps(payload) + "\n")
 
 
-def cloud_event(func: CloudEventFunction) -> CloudEventFunction:
+def cloud_event(func: _CloudEventFunctionT) -> _CloudEventFunctionT:
     """Decorator that registers cloudevent as user function signature type."""
     _function_registry.REGISTRY_MAP[func.__name__] = (
         _function_registry.CLOUDEVENT_SIGNATURE_TYPE
@@ -80,7 +85,7 @@ def cloud_event(func: CloudEventFunction) -> CloudEventFunction:
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
-    return wrapper
+    return wrapper  # type: ignore[return-value]
 
 
 def typed(*args):
@@ -110,7 +115,7 @@ def typed(*args):
         return _typed
 
 
-def http(func: HTTPFunction) -> HTTPFunction:
+def http(func: _HTTPFunctionT) -> _HTTPFunctionT:
     """Decorator that registers http as user function signature type."""
     _function_registry.REGISTRY_MAP[func.__name__] = (
         _function_registry.HTTP_SIGNATURE_TYPE
@@ -120,7 +125,7 @@ def http(func: HTTPFunction) -> HTTPFunction:
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
-    return wrapper
+    return wrapper  # type: ignore[return-value]
 
 
 def setup_logging():


### PR DESCRIPTION
## Problem

The `@functions_framework.http` and `@functions_framework.cloud_event` decorators had fixed signatures that erased the user function's type:

```python
def http(func: HTTPFunction) -> HTTPFunction: ...
```

After decoration, mypy and pyright saw the function as the generic `HTTPFunction = Callable[[flask.Request], ResponseReturnValue]` alias, losing all specific type information (custom return types, subclassed request types, etc.).

**Example that failed type checking before this fix:**
```python
@functions_framework.http
def handle(request: flask.Request) -> flask.Response:
    return flask.Response("ok")

reveal_type(handle)
# Before: HTTPFunction (generic alias, return type lost)
# After:  (request: flask.Request) -> flask.Response (preserved)
```

## Fix

Introduce bounded TypeVars for each decorator so the user's exact callable type flows through unchanged:

```python
_HTTPFunctionT = TypeVar("_HTTPFunctionT", bound=HTTPFunction)

def http(func: _HTTPFunctionT) -> _HTTPFunctionT: ...
```

The `# type: ignore[return-value]` on the return is the standard pattern for typed decorator implementations — mypy cannot verify that the inner `wrapper(*args, **kwargs)` satisfies the TypeVar bound, but `functools.wraps` guarantees the runtime behaviour is correct.

## Changes

- `src/functions_framework/__init__.py`
  - Add `TypeVar` to typing imports
  - Add `_CloudEventFunctionT` and `_HTTPFunctionT` TypeVars
  - Update `cloud_event()` and `http()` signatures to use TypeVars

## Backward Compatibility

Purely additive from a runtime perspective — no behaviour changes. Type checkers now get more precise information rather than less.

Fixes #361

🤖 Generated with Claude Code