### PR TITLE
chore(ci): update allowed endpoints for harden-runner

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,9 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
+            api.securityscorecards.dev:443
             github.com:443
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -42,6 +42,7 @@ jobs:
           github.com:443
           objects.githubusercontent.com:443
           production.cloudflare.docker.com:443
+          production.cloudfront.docker.com:443
           pypi.org:443
           registry-1.docker.io:443
           release-assets.githubusercontent.com:443


### PR DESCRIPTION
Some CI tests are broken due to network policy blocking API calls